### PR TITLE
ss push: prompt the user to confirm additional pushes to the same level

### DIFF
--- a/scripts/ShortStack.psm1
+++ b/scripts/ShortStack.psm1
@@ -1458,7 +1458,14 @@ function sspush($force)
     {
         if($force -ne "--force")
         {
-            throw "A commit has already been pushed to this level in the stack.  Use --force if you really want to add another commit at this level."
+            write-host -ForegroundColor Yellow "Warning: A commit has already been pushed to this level in the stack!"
+            $response = read-host -Prompt "Are you sure you want to push these changes here [y/N]? "
+            write-host -ForegroundColor Gray "(In the future, you can use --force to skip this question)."
+            if($response.Trim() -inotlike 'Y*')
+            {
+                write-host "Push canceled."
+                return
+            }
         }
 
         write-host "Pushing changes up to $currentBranch..."


### PR DESCRIPTION
When pushing additional changes to the current level (say, a bug fix or other amendment to the current thesis), shortstack merely informs the user that they must use --force and then bails.

This change alters the default behavior to instead ask the user if they're serious. If they confirm their intentions, it lets the change go through. A default or negative response is non-destructive. Either way, they are told that they can skip this prompt in the future with --force.

The behavior looks like:

![image](https://user-images.githubusercontent.com/14815901/67152936-c8d51480-f294-11e9-9217-04075d76a0f0.png)
