### PR TITLE
Change long-form PR Links in Completion PR to use VSTS ! markdown syntax

### DIFF
--- a/scripts/ShortStack.psm1
+++ b/scripts/ShortStack.psm1
@@ -1282,7 +1282,7 @@ function ssfinish($name, $desiredOrigin, $deleteFlag)
         }
     }
     $branchRoot = "refs/heads/" + $stackInfo.Template
-    $pullRequestLinks = "### Links to Stacked Pull requests: `n"
+    $pullRequestLinks = "### Links to Stacked Pull Requests: `n"
     foreach($pullRequest in $pullRequests)
     {
         $description += $pullRequest."title" + "`n"
@@ -1298,11 +1298,10 @@ function ssfinish($name, $desiredOrigin, $deleteFlag)
             $jsonPatch.Add('lastMergeSourceCommit', '{ "commitId": "' + $lastCommitId + '" } ')
             patch_pull_request $pullRequest $jsonPatch
 
-            $repositoryUrl = $pullRequest."repository"."url"
-            $remoteWebUrl = ((rest_get $repositoryUrl)."remoteUrl") + "/pullrequest/" + $pullRequest."pullRequestId"
-            $prBranchNumber = ($pullRequest."sourceRefName").SubString($branchRoot.Length)
-            $linkDisplayText = $stackInfo.Name + "_$prBranchNumber " + $pullRequest."title" 
-            $pullRequestLinks += "* [$linkDisplayText]($remoteWebUrl)`n"
+            # VSTS markdown will automatically add links to Pull Requests if the IDs
+            # are prefixed with an exclamation point, e.g.: !123456
+            $pullRequestLinks += "!{0}`n" -f $pullRequest."pullRequestId"
+
             # Sleep to let the commits from the completed PR catch up
             Start-Sleep -Milliseconds 2000
        }


### PR DESCRIPTION
In the Completion PR, shortstack builds a list of links to all the PRs in the stack via traditional markdown syntax by capturing the current PR titles and building links with them.

As it happens, VSTS now supports a markdown-esque shorthand for PR links, with the added benefit of always keeping the PR titles up-to-date. This PR changes the link-generation to use the new VSTS markdown shorthand, e.g.:

```
### Links to Stacked Pull Requests: 
* !3907969
* !3907967
* !3907911
* !3907901
* !3906524
```

The above renders in VSTS like:

![image](https://user-images.githubusercontent.com/14815901/67153165-37b46c80-f299-11e9-9441-7e56788bac96.png)
